### PR TITLE
Feat/settlement

### DIFF
--- a/homs-fe/src/components/common/SideBar.vue
+++ b/homs-fe/src/components/common/SideBar.vue
@@ -93,7 +93,7 @@ const getPath = (basePath: string, adminOnly?: boolean): string => {
       title: '정산 관리',
       icon: 3,
       open: false,
-      children: [{ name: '정산 현황', path: '/settlements' }], // 관리자O, 사용자O
+      children: [{ name: '정산 현황', path: getPath('/settlements'), adminOnly:true }], // 관리자O, 사용자O
     },
     {
       title: '공지사항',

--- a/homs-fe/src/components/common/modal/TaxInvoice.vue
+++ b/homs-fe/src/components/common/modal/TaxInvoice.vue
@@ -40,16 +40,16 @@
             </div>
 
             <!-- 업태 -->
-            <label class=" flex items-center pl-3 h-full bg-gray-200 border border-gray-300 font-semibold self-center">업종</label>
+            <!-- <label class=" flex items-center pl-3 h-full bg-gray-200 border border-gray-300 font-semibold self-center">업종</label>
             <div class="col-span-2 p-2 border border-gray-300">
                 <input v-model="invoiceForm.typeOfBusiness" type="text" class="flex w-1/3 border border-gray-300 text-md">
-            </div>
+            </div> -->
 
             <!-- 종류 -->
-            <label class=" flex items-center pl-3 h-full bg-gray-200 border border-gray-300 font-semibold self-center">종류</label>
+            <!-- <label class=" flex items-center pl-3 h-full bg-gray-200 border border-gray-300 font-semibold self-center">종류</label>
             <div class="col-span-2 p-2 border border-gray-300">
                 <input v-model="invoiceForm.industry" type="text" class="flex w-1/3 border border-gray-300 text-md">
-            </div>
+            </div> -->
         </div>
 
         <p class="mt-8 mx-10 text-gray-700 text-md font-extrabold">
@@ -73,11 +73,13 @@
 <script setup>
 import xmark from '@/assets/xmark.svg';
 import DynamicTable from '../DynamicTable.vue';
-import { ref, reactive } from 'vue';
+import { ref, reactive, watch } from 'vue';
+import apiClient from '@/api';
 
 
-defineProps({
-    visible: Boolean
+const props = defineProps({
+    visible: Boolean,
+    orderId: Number
 })
 const emit = defineEmits(['confirm'])
 
@@ -94,13 +96,10 @@ function onIssued() {
 }
 
 const invoiceForm = reactive({
-    contury:'',
     companyName:'',
     companyNumber: '',
     ceoName:'',
     companyAdress:'',
-    typeOfBusiness:'',
-    industry:'',
 })
 
 const orderColumns = ref([
@@ -108,10 +107,10 @@ const orderColumns = ref([
   { label: '일', key: 'day' },
   { label: '품목', key: 'product' },
   { label: '수량', key: 'quantity' },
-  { label: '단가', key: 'unitPrice' },
-  { label: '공급가액', key: 'supplyPrice' },
-  { label: '세액', key: 'taxPrice' },
-  { label: '상태', key: 'orderStatus' },
+//   { label: '단가', key: 'unitPrice' },
+//   { label: '공급가액', key: 'supplyPrice' },
+//   { label: '세액', key: 'taxPrice' },
+//   { label: '상태', key: 'orderStatus' },
 ]);
 
 const orderList = ref([
@@ -119,5 +118,45 @@ const orderList = ref([
     { month: 1, day: '23', product: 'LLDP-C', quantity: '10', unitPrice: '2,000', supplyPrice: '20,000', taxPrice:'2,000', orderStatus: '-'},
     { month: 1, day: '23', product: 'C-PPLP', quantity: '50', unitPrice: '10,000', supplyPrice: '500,000', taxPrice:'50,000', orderStatus: '-'},
 ]);
+
+const fetchData = async() => {
+    if(!props.orderId) return;
+
+    try{
+        const companyRes = await apiClient.get(`/settlement/${props.orderId}/companyInfo`);
+        const companyData = companyRes.data.data;
+        console.log("주문별 거래처 조회",companyData);
+        Object.assign(invoiceForm, {
+            companyName: companyData.companyName,
+            companyNumber: companyData.registrationNumber,
+            ceoName: companyData.representName,
+            companyAdress: companyData.address
+        });
+
+        const orderRes = await apiClient.get(`/settlement/${props.orderId}/orderInfo`);
+        const orderData = orderRes.data.data
+        console.log("주문별 주문상품 조회", orderData);
+        orderList.value = orderData.map(item => ({
+            month: new Date(item.orderDate).getMonth(),
+            day: new Date(item.orderDate).getDate(),
+            product: item.productName,
+            quantity: item.quantity,
+            // unitPrice: item.unitPrice,
+            // supplyPrice: item.supplyPrice,
+            // taxPrice: item.taxPrice,
+            // orderStatus: item.orderStatus
+        }));
+    }catch(error){
+        console.log("주문 거래처 정보 불러오기 실패",error)
+    }
+}
+
+
+watch(() => props.orderId, (newVal) => {
+  if (newVal) fetchData();
+});
+
+
+
   </script>
   

--- a/homs-fe/src/main.ts
+++ b/homs-fe/src/main.ts
@@ -24,6 +24,6 @@ app.component("font-awesome-icon", FontAwesomeIcon);
 // 권한 관련
 import { userStore } from './states/user'
 const userAuth = userStore()
-userAuth.setRole('user')
+userAuth.setRole('admin')
 
 app.mount('#app')

--- a/homs-fe/src/pages/admin/settlement/Settlements.vue
+++ b/homs-fe/src/pages/admin/settlement/Settlements.vue
@@ -27,30 +27,17 @@
               </span>
             </template>
               <template #actions="{ item }">
-                <div v-if="role === 'admin'">
+
                   <button @click="issuingTaxInvoices(item)"
                       class=" bg-orange-500 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded text-sm">
                       발행
                   </button>
-                </div>
-                <div v-else-if="role === 'user'">
-                  <span class="text-gray-500">
-                    <button @click="checkTaxInvoice(item)"
-                      :disabled="item.isSettled === '미정산'"
-                      :class="[ 'font-bold py-2 px-4 rounded text-sm',
-                                 item.isSettled === '미정산' ? 'bg-gray-400 text-white cursor-not-allowed' : 'bg-orange-500 hover:bg-orange-700 text-white'
-                        ]">
-                      확인
-                    </button>
-                </span>
-
-                </div>
               </template>
         </DynamicTable>
         <!-- 페이지 네비 -->
         <PageNav :currentPage="currentPage" :totalPages="totalPages" @set-page="handleSetPage"></PageNav>
 
-        <TaxInvoice :visible="showTIModal" @confirm="confirmModal" />
+        <TaxInvoice :visible="showTIModal" :order-id="selectedOrderId" @confirm="confirmModal" />
         <CheckTaxInvoice :visible="showCheckModal" @confirm="confirmCheckTaxInvoice" ></CheckTaxInvoice>
     </div>
 </template>
@@ -61,9 +48,8 @@ import DynamicTable from '@/components/common/DynamicTable.vue';
 import PageNav from '@/components/common/PageNav.vue';
 import TaxInvoice from '@/components/common/modal/TaxInvoice.vue';
 import CheckTaxInvoice from '@/components/common/modal/CheckTaxInvoice.vue';
-import { ref } from 'vue';
-import { userStore } from '@/states/user';
-import { storeToRefs } from 'pinia'
+import { ref,onMounted } from 'vue';
+import apiClient from '@/api';
 
 const searchResult = ref(null);
 const currentPage = ref(1); // 현재 페이지 상태 관리
@@ -71,10 +57,55 @@ const totalPages = ref(20); // 총 페이지 수 상태 관리
 // 모달 관련
 const showTIModal = ref(false);
 const showCheckModal = ref(false);
-// 사용자 권한 관련
-const store = userStore()
-const { role, isAdmin } = storeToRefs(store)
 
+const selectedOrderId = ref(null);
+
+
+// 데이터
+const users = ref([
+    { id: 1, orderCode: 'H-04-23', companyName: '영광상사', deliveryName: '서울', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'미정산', orderStatus: '-'},
+    { id: 2, orderCode: 'H-04-23', companyName: '영광상사', deliveryName: '서울', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'대기', orderStatus: '반품/교환'},
+    { id: 3, orderCode: 'H-04-23', companyName: '하이젠버그', deliveryName: '미국', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'완료', orderStatus: '-'},
+]);
+
+const handleSelectOption = ref([
+  { value: "", label: "전체" },
+  { value: "important", label: "중요" },
+  { value: "recent", label: "최근" },
+]);
+
+const fetchData = async() => {
+  try{
+    const response = await apiClient.get('/settlement/');
+    const data = response.data.data;
+    console.log("정산 데이터", data);
+    users.value = data.map((item, index) => ({
+      id: index +1,
+      orderCode: item.orderCode,
+      companyName: item.companyName,
+      deliveryName: item.companyAddress,
+      orderDate: new Date(item.orderDate).toISOString().split('T')[0] ,
+      settlementDate: new Date(item.settlementDate).toISOString().split('T')[0],
+      isSettled: mapSettlementStatus(item.isSettled),
+      orderStatus: item.orderStatus ?? '-',
+    }));
+  }catch(error) {
+    console.log('정산 테이블을 불러오는데 실패 하였습니다', error);
+  }
+}
+
+const mapSettlementStatus = (status) => {
+  switch (status) {
+    case 'SETTLED':
+      return '완료';
+    case 'UNSETTLED':
+      return '미정산';
+    case 'WAITING':
+      return '대기';
+    default:
+      return '알 수 없음'; // 예외 처리
+  }
+};
 
 
 // ------- 검색바 --------
@@ -83,12 +114,6 @@ const handleSearch = (searchData) => {
   // 여기서 검색 로직을 처리하거나 부모 컴포넌트로 데이터를 전달할 수 있습니다.
   searchResult.value = searchData;
 };
-
-const handleSelectOption = ref([
-  { value: "", label: "전체" },
-  { value: "important", label: "중요" },
-  { value: "recent", label: "최근" },
-]);
 
 // ------- 테이블 --------
 //헤더
@@ -103,16 +128,16 @@ const userColumns = ref([
   { label: '상태', key: 'orderStatus' },
 ]);
 
-// 데이터
-const users = ref([
-    { id: 1, orderCode: 'H-04-23', companyName: '영광상사', deliveryName: '서울', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'미정산', orderStatus: '-'},
-    { id: 2, orderCode: 'H-04-23', companyName: '영광상사', deliveryName: '서울', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'대기', orderStatus: '반품/교환'},
-    { id: 3, orderCode: 'H-04-23', companyName: '하이젠버그', deliveryName: '미국', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'완료', orderStatus: '-'},
-]);
+// ------- 페이지네이션 --------
+const handleSetPage = (page) => {
+  console.log('페이지 변경 요청:', page);
+  currentPage.value = page;
+  // 여기서 해당 페이지의 데이터를 불러오는 로직 등을 수행해야 합니다.
+};
 
 const issuingTaxInvoices = (order) => {
   showTIModal.value=true;
-  console.log('발행:', order);
+  selectedOrderId.value = order.id;
 };
 
 const checkTaxInvoice =  (order) =>{
@@ -127,12 +152,7 @@ const confirmCheckTaxInvoice = (order) => {
   showCheckModal.value = false
 }
 
-
-// ------- 페이지네이션 --------
-const handleSetPage = (page) => {
-  console.log('페이지 변경 요청:', page);
-  currentPage.value = page;
-  // 여기서 해당 페이지의 데이터를 불러오는 로직 등을 수행해야 합니다.
-};
-
+onMounted(() =>{
+  fetchData();
+})
 </script>

--- a/homs-fe/src/pages/user/settlement/Settlements.vue
+++ b/homs-fe/src/pages/user/settlement/Settlements.vue
@@ -1,90 +1,166 @@
 <template>
-    <div>
-        <!-- 제목 -->
-        <div class="text-3xl px-3 py-3">
-            <span>정산관리</span>
-        </div>
-        <!-- 검색바 -->
-        <SearchBox @search="handleSearch" :selectOptions="handleSelectOption" :buttons="actionButtons"
-            :userRole="currentUserRole" />
-        <!-- 테이블 -->
-        <DynamicTable :columns="userColumns" :items="users" :showCheckbox="false" action="세금계산서">
-            <template #cell-id="{ item }">
-                <strong>{{ item.id }}</strong>
-            </template>
-            <template #cell-name="{ item }">
-                {{ item.name }}
-            </template>
-            <template #cell-email="{ item }">
-                <a :href="`mailto:${item.email}`">{{ item.email }}</a>
-            </template>
+  <div>
+      <!-- 제목 -->
+      <div class="text-3xl px-3 py-3">
+          <span>정산관리</span>
+      </div>
+      <!-- 검색바 -->
+      <SearchBox @search="handleSearch" :selectOptions="handleSelectOption" :buttons="actionButtons"
+          :userRole="currentUserRole" />
+      <!-- 테이블 -->
+      <DynamicTable :columns="userColumns" :items="users" :showCheckbox="false" action="세금계산서" >
+          <template #cell-id="{ item }">
+              <strong>{{ item.id }}</strong>
+          </template>
+          <template #cell-name="{ item }">
+              {{ item.name }}
+          </template>
+          <template #cell-isSettled="{ item }">
+            <span
+                :class="{
+                  'text-red-500': item.isSettled === '미정산',
+                  'text-yellow-500': item.isSettled === '대기',
+                  'text-green-500': item.isSettled === '완료'
+                }"
+            >
+                {{ item.isSettled }}
+            </span>
+          </template>
             <template #actions="{ item }">
-                <button @click="editUser(item)"
-                    class="bg-orange-500 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded text-sm mr-2">
-                    발행
-                </button>
+                <span class="text-gray-500">
+                  <button @click="checkTaxInvoice(item)"
+                    :disabled="item.isSettled === '미정산'"
+                    :class="[ 'font-bold py-2 px-4 rounded text-sm',
+                               item.isSettled === '미정산' ? 'bg-gray-400 text-white cursor-not-allowed' : 'bg-orange-500 hover:bg-orange-700 text-white'
+                      ]">
+                    확인
+                  </button>
+              </span>
             </template>
-        </DynamicTable>
-        <!-- 페이지 네비 -->
-        <PageNav :currentPage="currentPage" :totalPages="totalPages" @set-page="handleSetPage"></PageNav>
-    </div>
+      </DynamicTable>
+      <!-- 페이지 네비 -->
+      <PageNav :currentPage="currentPage" :totalPages="totalPages" @set-page="handleSetPage"></PageNav>
+
+      <TaxInvoice :visible="showTIModal" @confirm="confirmModal" />
+      <CheckTaxInvoice :visible="showCheckModal" @confirm="confirmCheckTaxInvoice" ></CheckTaxInvoice>
+  </div>
 </template>
 
 <script setup>
 import SearchBox from '@/components/common/SaerchBar.vue';
 import DynamicTable from '@/components/common/DynamicTable.vue';
 import PageNav from '@/components/common/PageNav.vue';
-import { ref } from 'vue';
+import TaxInvoice from '@/components/common/modal/TaxInvoice.vue';
+import CheckTaxInvoice from '@/components/common/modal/CheckTaxInvoice.vue';
+import { ref,onMounted } from 'vue';
+import { userStore } from '@/states/user';
+import { storeToRefs } from 'pinia'
+import apiClient from '@/api';
 
 const searchResult = ref(null);
 const currentPage = ref(1); // 현재 페이지 상태 관리
 const totalPages = ref(20); // 총 페이지 수 상태 관리
-const currentUserRole = ref('admin'); // 현재 유저 권한
+// 모달 관련
+const showTIModal = ref(false);
+const showCheckModal = ref(false);
+// 계정 관련
+const store = userStore();
+const { userId } = storeToRefs(store); 
+
+// 데이터
+const users = ref([
+  { id: 1, orderCode: 'H-04-23', companyName: '영광상사', deliveryName: '서울', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'미정산', orderStatus: '-'},
+  { id: 2, orderCode: 'H-04-23', companyName: '영광상사', deliveryName: '서울', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'대기', orderStatus: '반품/교환'},
+  { id: 3, orderCode: 'H-04-23', companyName: '하이젠버그', deliveryName: '미국', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'완료', orderStatus: '-'},
+]);
+
+const handleSelectOption = ref([
+{ value: "", label: "전체" },
+{ value: "important", label: "중요" },
+{ value: "recent", label: "최근" },
+]);
+
+const fetchData = async() => {
+try{
+  // 나중에 유저 연결했을때 유저 정보 받아오는 부분
+  // const response = await apiClient.get('settlement/user/{userId.value}');
+  const response = await apiClient.get('/settlement/user/2');
+  const data = response.data.data;
+  console.log("정산 데이터", data);
+  users.value = data.map((item, index) => ({
+    id: index +1,
+    orderCode: item.orderCode,
+    companyName: item.companyName,
+    deliveryName: item.companyAddress,
+    orderDate: new Date(item.orderDate).toISOString().split('T')[0],
+    settlementDate: new Date(item.settlementDate).toISOString().split('T')[0],
+    isSettled: mapSettlementStatus(item.isSettled),
+    orderStatus: item.orderStatus ?? '-',
+  }));
+}catch(error) {
+  console.log('정산 테이블을 불러오는데 실패 하였습니다', error);
+}
+}
+
+const mapSettlementStatus = (status) => {
+switch (status) {
+  case 'SETTLED':
+    return '완료';
+  case 'UNSETTLED':
+    return '미정산';
+  case 'WAITING':
+    return '대기';
+  default:
+    return '알 수 없음'; // 예외 처리
+}
+};
+
 
 // ------- 검색바 --------
 const handleSearch = (searchData) => {
-  console.log('검색 데이터:', searchData);
-  // 여기서 검색 로직을 처리하거나 부모 컴포넌트로 데이터를 전달할 수 있습니다.
-  searchResult.value = searchData;
+console.log('검색 데이터:', searchData);
+// 여기서 검색 로직을 처리하거나 부모 컴포넌트로 데이터를 전달할 수 있습니다.
+searchResult.value = searchData;
 };
-
-const handleSelectOption = ref([
-  { value: "", label: "전체" },
-  { value: "important", label: "중요" },
-  { value: "recent", label: "최근" },
-]);
 
 // ------- 테이블 --------
+//헤더
 const userColumns = ref([
-  { label: '순번', key: 'id' },
-  { label: '발주번호', key: 'orderCode' },
-  { label: '거래처명', key: 'companyName' },
-  { label: '납품장소', key: 'deliveryName' },
-  { label: '요청일', key: 'orderDate' },
-  { label: '정산일', key: 'settlementDate' },
-  { label: '정산여부', key: 'isSettled' },
-  { label: '상태', key: 'orderStatus' },
+{ label: '순번', key: 'id' },
+{ label: '발주번호', key: 'orderCode' },
+{ label: '거래처명', key: 'companyName' },
+{ label: '납품장소', key: 'deliveryName' },
+{ label: '요청일', key: 'orderDate' },
+{ label: '정산일', key: 'settlementDate' },
+{ label: '정산여부', key: 'isSettled' },
+{ label: '상태', key: 'orderStatus' },
 ]);
-
-const users = ref([
-    { id: 1, orderCode: 'H-04-23', companyName: '영광상사', deliveryName: '서울', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'미정산', orderStatus: '-'},
-    { id: 2, orderCode: 'H-04-23', companyName: '영광상사', deliveryName: '서울', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'대기', orderStatus: '반품/교환'},
-    { id: 3, orderCode: 'H-04-23', companyName: '하이젠버그', deliveryName: '미국', orderDate: '25-04-02', settlementDate: '25-04-11', isSettled:'완료', orderStatus: '-'},
-]);
-
-const editUser = (user) => {
-  console.log('수정:', user);
-};
-
-const deleteUser = (user) => {
-  console.log('삭제:', user);
-};
 
 // ------- 페이지네이션 --------
 const handleSetPage = (page) => {
-  console.log('페이지 변경 요청:', page);
-  currentPage.value = page;
-  // 여기서 해당 페이지의 데이터를 불러오는 로직 등을 수행해야 합니다.
+console.log('페이지 변경 요청:', page);
+currentPage.value = page;
+// 여기서 해당 페이지의 데이터를 불러오는 로직 등을 수행해야 합니다.
 };
 
+const issuingTaxInvoices = (order) => {
+showTIModal.value=true;
+console.log('발행:', order);
+};
+
+const checkTaxInvoice =  (order) =>{
+showCheckModal.value =  true;
+}
+
+function confirmModal(){
+showTIModal.value=false;
+}
+
+const confirmCheckTaxInvoice = (order) => {
+showCheckModal.value = false
+}
+
+onMounted(() =>{
+fetchData();
+})
 </script>

--- a/homs-fe/src/router/index.ts
+++ b/homs-fe/src/router/index.ts
@@ -14,6 +14,7 @@ import Clients from '@/pages/admin/clients/Clients.vue'
 import Contracts from '@/pages/admin/clients/Contracts.vue'
 import MenuSettings from '@/pages/admin/menu/MenuSettings.vue'
 import Login from '@/pages/common/login/Login.vue'
+import AdminSettlements from '@/pages/admin/settlement/Settlements.vue'
 
 // 유저 관련
 import UserDashBoard from "@/pages/user/dashboard/UserDashBoard.vue";
@@ -21,7 +22,7 @@ import Accounts from "@/pages/user/account/Account.vue";
 import Products from "@/pages/user/product/Products.vue";
 import Orders from "@/pages/user/order/Order.vue";
 import Deliverys from "@/pages/user/delivery/Delivery.vue";
-import Settlements from "@/pages/admin/settlement/Settlements.vue";
+import Settlements from "@/pages/user/settlement/Settlements.vue";
 import Notices from "@/pages/user/notice/Notices.vue";
 import NoticesDetail from "@/pages/user/notice/NoticesDetail.vue";
 import AdminNoticesForm from "@/pages/admin/notice/NoticesForm.vue";
@@ -56,6 +57,12 @@ const router = createRouter({
           path: "adminaccount",
           name: "AdminAccount",
           component: AdminAccount,
+          meta: {requiresAuth: true, role: "admin"},
+        },
+        {
+          path: "settlements",
+          name: "AdminSettlement",
+          component: AdminSettlements,
           meta: {requiresAuth: true, role: "admin"},
         },
         {


### PR DESCRIPTION
- 정산 관리 데이터 바인딩 까지 완료

- 기존에는 user페이지에서 admin일 경우 버튼이 생성 되고 user일 경우 버튼이 숨겨지는 방식으로 진행했는데 
- 구현하다보니 안에 들어가는 데이터도 다르고 버튼의 유무도 다르다 보니 admin과 user을 나누는 방식으로 진행하기로 함
- 정산 관리 → 세금 계산서 발행 부분

- 공급액, 세액, 총액 은 데이터에서 보여주기 민감한 데이터이기도 하고 기존의 DB에도 기재된 부분도 없어서 빼기로 결정